### PR TITLE
BOT: Dart Dependency Updater

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [1.1.4+11] - January 28, 2025
+
+* Automated dependency updates
+
+
 ## [1.1.4+10] - May 14, 2024
 
 * Automated dependency updates
@@ -202,36 +207,3 @@
 ## [1.0.0+1] - April 3rd, 2022
 
 * Initial release
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,45 +1,40 @@
 name: 'yaon'
 description: 'A simple library to parse either a string from either yaml or json.'
 homepage: 'https://github.com/peiffer-innovations/yaon'
-version: '1.1.4+10'
+version: '1.1.4+11'
 
 environment:
   sdk: '>=3.0.0 <4.0.0'
 
 dependencies:
-  logging: '^1.2.0'
-  yaml: '^3.1.2'
+  logging: '^1.3.0'
+  yaml: '^3.1.3'
 
 dev_dependencies:
-  bson: '^5.0.4'
+  bson: '^5.0.5'
   flutter_lints: '^5.0.0'
-  test: '^1.25.5'
-  yaml_writer: '^2.0.0'
+  test: '^1.25.14'
+  yaml_writer: '^2.0.1'
 
 permittedLicenses:
-  - Apache-2.0
-  - BSD-2-Clause
-  - BSD-3-Clause
-  - MIT
-  - MIT-Modern-Variant
-  - MPL-2.0
-  - Zlib
+  - 'Apache-2.0'
+  - 'BSD-2-Clause'
+  - 'BSD-3-Clause'
+  - 'MIT'
+  - 'MIT-Modern-Variant'
+  - 'MPL-2.0'
+  - 'Zlib'
 
-# The [license_checker](https://pub.dev/packages/license_checker) package cannot
-# detect the built in Flutter packages because they aren't published to pub.dev
-# and do not have a LICENSE file in their respective folders.  So this section
-# informs the license_checker that all the built in Flutter packages all have
-# the same BSD-3-Clause license as Flutter itself.
 packageLicenseOverride:
-  flutter: BSD-3-Clause
-  flutter_driver: BSD-3-Clause
-  flutter_goldens: BSD-3-Clause
-  flutter_localizations: BSD-3-Clause
-  flutter_web_plugins: BSD-3-Clause
-  flutter_test: BSD-3-Clause
-  fuchsia_remote_debug_protocol: BSD-3-Clause
-  integration_test: BSD-3-Clause
-  rxdart: Apache-2.0
+  flutter: 'BSD-3-Clause'
+  flutter_driver: 'BSD-3-Clause'
+  flutter_goldens: 'BSD-3-Clause'
+  flutter_localizations: 'BSD-3-Clause'
+  flutter_web_plugins: 'BSD-3-Clause'
+  flutter_test: 'BSD-3-Clause'
+  fuchsia_remote_debug_protocol: 'BSD-3-Clause'
+  integration_test: 'BSD-3-Clause'
+  rxdart: 'Apache-2.0'
 
 ignore_updates:
   - 'archive'


### PR DESCRIPTION
PR created automatically


dependencies:
  * `logging`: 1.2.0 --> 1.3.0
  * `yaml`: 3.1.2 --> 3.1.3

dev_dependencies:
  * `bson`: 5.0.4 --> 5.0.5
  * `test`: 1.25.5 --> 1.25.14
  * `yaml_writer`: 2.0.0 --> 2.0.1


Analysis Successful

